### PR TITLE
implement CSIPgetObjBound

### DIFF
--- a/include/csip.h
+++ b/include/csip.h
@@ -109,6 +109,9 @@ CSIP_RETCODE CSIPgetVarValues(CSIP_MODEL *model, double *output);
 // Get the objective value of the best-known solution.
 double CSIPgetObjValue(CSIP_MODEL *model);
 
+// Get the best known bound on the optimal solution
+double CSIPgetObjBound(CSIP_MODEL *model);
+
 // Get the solving status.
 CSIP_STATUS CSIPgetStatus(CSIP_MODEL *model);
 

--- a/src/csip.c
+++ b/src/csip.c
@@ -542,8 +542,8 @@ CSIP_RETCODE CSIPsolve(CSIP_MODEL *model)
     SCIP_in_CSIP(SCIPsolve(model->scip));
     model->status = getStatus(model);
 
-    double objbound = SCIPgetDualbound(model->scip);
-    model->objbound = (model->sense == SCIP_OBJSENSE_MINIMIZE ? objbound : -objbound);
+    double dual = SCIPgetDualbound(model->scip);
+    model->objbound = (model->sense == SCIP_OBJSENSE_MINIMIZE ? dual : -dual);
 
     SCIP_in_CSIP(SCIPfreeTransform(model->scip));
 

--- a/test/test.c
+++ b/test/test.c
@@ -90,6 +90,8 @@ static void test_mip()
 
     double objval = CSIPgetObjValue(m);
     mu_assert_near("Wrong objective value!", objval, -16.0);
+    double objbound = CSIPgetObjBound(m);
+    mu_assert_near("Wrong objective bound!", objbound, -16.0);
 
     CHECK(CSIPgetVarValues(m, solution));
     mu_assert_near("Wrong solution!", solution[0], 1.0);


### PR DESCRIPTION
I was trying to address the failure of the mixintprog tests (https://github.com/leethargo/SCIP.jl/commit/4a6bfd3f35551094d0543bf5ba72f3105bfc70e7) by implementing ``getobjbound``, but this code segfaults. Am I doing something wrong?