### PR TITLE
allow for quadratic objectives

### DIFF
--- a/include/csip.h
+++ b/include/csip.h
@@ -101,10 +101,10 @@ CSIP_RETCODE CSIPsetObj(
 
 // Set a quadratic objective function
 CSIP_RETCODE CSIPsetQuadObj(CSIP_MODEL *model, int numlinindices,
-                             int *linindices,
-                             double *lincoefs, int numquadterms,
-                             int *quadrowindices, int *quadcolindices,
-                             double *quadcoefs);
+                            int *linindices,
+                            double *lincoefs, int numquadterms,
+                            int *quadrowindices, int *quadcolindices,
+                            double *quadcoefs);
 
 // Set the optimization sense to minimization. This is the default setting.
 CSIP_RETCODE CSIPsetSenseMinimize(CSIP_MODEL *model);

--- a/include/csip.h
+++ b/include/csip.h
@@ -99,6 +99,13 @@ CSIP_RETCODE CSIPaddSOS2(
 CSIP_RETCODE CSIPsetObj(
     CSIP_MODEL *model, int numindices, int *indices, double *coefs);
 
+// Set a quadratic objective function
+CSIP_RETCODE CSIPsetQuadObj(CSIP_MODEL *model, int numlinindices,
+                             int *linindices,
+                             double *lincoefs, int numquadterms,
+                             int *quadrowindices, int *quadcolindices,
+                             double *quadcoefs);
+
 // Set the optimization sense to minimization. This is the default setting.
 CSIP_RETCODE CSIPsetSenseMinimize(CSIP_MODEL *model);
 

--- a/src/csip.c
+++ b/src/csip.c
@@ -208,25 +208,25 @@ CSIP_RETCODE reformSenseMinimize(CSIP_MODEL *model)
             SCIP_in_CSIP(SCIPchgVarObj(model->scip, var, -1.0 * coef));
         }
 
-        if( model->objvar != NULL )
+        if (model->objvar != NULL)
         {
-           // the first time we are here the problem is: max t s.t objcons - t <= 0
-           // but it should be max t s.t. objcons >= t, or equivalently
-           // min -t s.t 0 <= objcons - t
-           // the second time we are called, we have to set it back as before (TODO: is this really necessary?)
-           if( SCIPgetRhsQuadratic(model->scip, model->objcons) == 0.0 )
-           {
-              SCIP_in_CSIP(SCIPchgLhsQuadratic(model->scip, model->objcons, 0.0));
-              SCIP_in_CSIP(SCIPchgRhsQuadratic(model->scip, model->objcons, INFINITY));
-              SCIP_in_CSIP(SCIPchgVarObj(model->scip, model->objvar, -1.0));
-           }
-           else
-           {
-              /* FIXME: related to the TODO above:,this is just wrong! */
-              SCIP_in_CSIP(SCIPchgLhsQuadratic(model->scip, model->objcons, -INFINITY));
-              SCIP_in_CSIP(SCIPchgRhsQuadratic(model->scip, model->objcons, 0.0));
-              SCIP_in_CSIP(SCIPchgVarObj(model->scip, model->objvar, 1.0));
-           }
+            // the first time we are here the problem is: max t s.t objcons - t <= 0
+            // but it should be max t s.t. objcons >= t, or equivalently
+            // min -t s.t 0 <= objcons - t
+            // the second time we are called, we have to set it back as before (TODO: is this really necessary?)
+            if (SCIPgetRhsQuadratic(model->scip, model->objcons) == 0.0)
+            {
+                SCIP_in_CSIP(SCIPchgLhsQuadratic(model->scip, model->objcons, 0.0));
+                SCIP_in_CSIP(SCIPchgRhsQuadratic(model->scip, model->objcons, INFINITY));
+                SCIP_in_CSIP(SCIPchgVarObj(model->scip, model->objvar, -1.0));
+            }
+            else
+            {
+                /* FIXME: related to the TODO above:,this is just wrong! */
+                SCIP_in_CSIP(SCIPchgLhsQuadratic(model->scip, model->objcons, -INFINITY));
+                SCIP_in_CSIP(SCIPchgRhsQuadratic(model->scip, model->objcons, 0.0));
+                SCIP_in_CSIP(SCIPchgVarObj(model->scip, model->objvar, 1.0));
+            }
         }
     }
     return CSIP_RETCODE_OK;
@@ -306,7 +306,7 @@ CSIP_RETCODE CSIPfreeModel(CSIP_MODEL *model)
     {
         SCIP_in_CSIP(SCIPreleaseCons(model->scip, &model->conss[i]));
     }
-    if( model->objvar != NULL )
+    if (model->objvar != NULL)
     {
         assert(model->objcons != NULL);
         SCIP_in_CSIP(SCIPreleaseVar(model->scip, &model->objvar));
@@ -550,7 +550,7 @@ CSIP_RETCODE CSIPsetObj(CSIP_MODEL *model, int numindices, int *indices,
     // if nonlinear objective was set, remove objvar from objective
     // and relax its bounds. This should render the objective constraint
     // redundant
-    if( model->objvar != NULL )
+    if (model->objvar != NULL)
     {
         SCIP_in_CSIP(SCIPchgVarObj(scip, model->objvar, 0.0));
         SCIP_in_CSIP(SCIPchgVarLb(scip, model->objvar, -SCIPinfinity(scip)));
@@ -567,10 +567,10 @@ CSIP_RETCODE CSIPsetObj(CSIP_MODEL *model, int numindices, int *indices,
 }
 
 CSIP_RETCODE CSIPsetQuadObj(CSIP_MODEL *model, int numlinindices,
-                             int *linindices,
-                             double *lincoefs, int numquadterms,
-                             int *quadrowindices, int *quadcolindices,
-                             double *quadcoefs)
+                            int *linindices,
+                            double *lincoefs, int numquadterms,
+                            int *quadrowindices, int *quadcolindices,
+                            double *quadcoefs)
 {
     int i;
     SCIP *scip;
@@ -599,7 +599,7 @@ CSIP_RETCODE CSIPsetQuadObj(CSIP_MODEL *model, int numlinindices,
     // if nonlinear objective was set before, remove objvar from objective
     // and relax its bounds. This should render the objective constraint
     // redundant
-    if( model->objvar != NULL )
+    if (model->objvar != NULL)
     {
         SCIP_in_CSIP(SCIPchgVarObj(scip, model->objvar, 0.0));
         SCIP_in_CSIP(SCIPchgVarLb(scip, model->objvar, -SCIPinfinity(scip)));
@@ -612,8 +612,8 @@ CSIP_RETCODE CSIPsetQuadObj(CSIP_MODEL *model, int numlinindices,
     assert(model->objvar == NULL);
     assert(model->objcons == NULL);
     SCIP_in_CSIP(SCIPcreateVarBasic(scip, &model->objvar, NULL,
-                 -SCIPinfinity(scip), SCIPinfinity(scip), 1.0,
-                 SCIP_VARTYPE_CONTINUOUS));
+                                    -SCIPinfinity(scip), SCIPinfinity(scip), 1.0,
+                                    SCIP_VARTYPE_CONTINUOUS));
     SCIP_in_CSIP(SCIPaddVar(scip, model->objvar));
     SCIP_in_CSIP(SCIPaddLinearVarQuadratic(scip, cons, model->objvar, -1.0));
 

--- a/src/csip.c
+++ b/src/csip.c
@@ -83,6 +83,13 @@ struct csip_model
 
     // store the best bound (for after freeTransform)
     double objbound;
+
+    // store objective variable for nonlinear objective: the idea is to add an
+    // auxiliary constraint and variable to represent nonlinear objectives. If
+    // the objective gets change, we set to 0 the objective coefficient of this
+    // variable and relax its bounds so the auxiliary constraint is redundant.
+    // This is going to mess the model when printed to a file.
+    SCIP_VAR *objvar;
 };
 
 /*
@@ -199,7 +206,8 @@ CSIP_RETCODE reformSenseMinimize(CSIP_MODEL *model)
             double coef = SCIPvarGetObj(var);
             SCIP_in_CSIP(SCIPchgVarObj(model->scip, var, -1.0 * coef));
         }
-
+        // TODO: currently we don't support MAXIMIZE with nonlinear objective
+        assert(model->objvar == NULL);
     }
     return CSIP_RETCODE_OK;
 }
@@ -245,6 +253,7 @@ CSIP_RETCODE CSIPcreateModel(CSIP_MODEL **modelptr)
     model->initialsol = NULL;
     model->status = CSIP_STATUS_UNKNOWN;
     model->objbound = strtod("NaN", NULL);
+    model->objvar = NULL;
 
     CSIP_CALL(CSIPsetParameter(model, "display/width", 80));
 
@@ -275,6 +284,10 @@ CSIP_RETCODE CSIPfreeModel(CSIP_MODEL *model)
     for (i = 0; i < model->nconss; ++i)
     {
         SCIP_in_CSIP(SCIPreleaseCons(model->scip, &model->conss[i]));
+    }
+    if( model->objvar != NULL )
+    {
+        SCIP_in_CSIP(SCIPreleaseVar(model->scip, &model->objvar));
     }
     SCIP_in_CSIP(SCIPfree(&model->scip));
 
@@ -510,6 +523,77 @@ CSIP_RETCODE CSIPsetObj(CSIP_MODEL *model, int numindices, int *indices,
         var = model->vars[indices[i]];
         SCIP_in_CSIP(SCIPchgVarObj(scip, var, coefs[i]));
     }
+
+    // if nonlinear objective was set, remove objvar from objective
+    // and relax its bounds. This should render the objective constraint
+    // redundant
+    if( model->objvar != NULL )
+    {
+        SCIP_in_CSIP(SCIPchgVarObj(scip, model->objvar, 0.0));
+        SCIP_in_CSIP(SCIPchgVarLb(scip, model->objvar, -SCIPinfinity(scip)));
+        SCIP_in_CSIP(SCIPchgVarUb(scip, model->objvar, SCIPinfinity(scip)));
+
+        // we do not need to remember this variable anymore
+        SCIP_in_CSIP(SCIPreleaseVar(scip, &model->objvar));
+        assert(model->objvar == NULL);
+    }
+
+    return CSIP_RETCODE_OK;
+}
+
+CSIP_RETCODE CSIPsetQuadObj(CSIP_MODEL *model, int numlinindices,
+                             int *linindices,
+                             double *lincoefs, int numquadterms,
+                             int *quadrowindices, int *quadcolindices,
+                             double *quadcoefs)
+{
+    int i;
+    SCIP *scip;
+    SCIP_VAR *linvar;
+    SCIP_VAR *var1;
+    SCIP_VAR *var2;
+    SCIP_CONS *cons;
+
+    scip = model->scip;
+
+    SCIP_in_CSIP(SCIPcreateConsBasicQuadratic(scip, &cons, "quadcons", 0, NULL,
+                 NULL, 0, NULL, NULL, NULL, -SCIPinfinity(scip), 0.0));
+
+    for (i = 0; i < numlinindices; ++i)
+    {
+        linvar = model->vars[linindices[i]];
+        SCIP_in_CSIP(SCIPaddLinearVarQuadratic(scip, cons, linvar, lincoefs[i]));
+    }
+    for (i = 0; i < numquadterms; ++i)
+    {
+        var1 = model->vars[quadrowindices[i]];
+        var2 = model->vars[quadcolindices[i]];
+        SCIP_in_CSIP(SCIPaddBilinTermQuadratic(scip, cons, var1, var2, quadcoefs[i]));
+    }
+
+    // if nonlinear objective was set before, remove objvar from objective
+    // and relax its bounds. This should render the objective constraint
+    // redundant
+    if( model->objvar != NULL )
+    {
+        SCIP_in_CSIP(SCIPchgVarObj(scip, model->objvar, 0.0));
+        SCIP_in_CSIP(SCIPchgVarLb(scip, model->objvar, -SCIPinfinity(scip)));
+        SCIP_in_CSIP(SCIPchgVarUb(scip, model->objvar, SCIPinfinity(scip)));
+
+        // we do not need to remember this variable anymore
+        SCIP_in_CSIP(SCIPreleaseVar(scip, &model->objvar));
+    }
+    assert(model->objvar == NULL);
+    SCIP_in_CSIP(SCIPcreateVarBasic(scip, &model->objvar, NULL,
+                 -SCIPinfinity(scip), SCIPinfinity(scip), 1.0,
+                 SCIP_VARTYPE_CONTINUOUS));
+    SCIP_in_CSIP(SCIPaddVar(scip, model->objvar));
+    SCIP_in_CSIP(SCIPaddLinearVarQuadratic(scip, cons, model->objvar, -1.0));
+
+    // add objective constraint and forget about
+    // TODO: we might have to remember to correctly handle maximization problems
+    SCIP_in_CSIP(SCIPaddCons(scip, cons));
+    SCIP_in_CSIP(SCIPreleaseCons(scip, &cons));
 
     return CSIP_RETCODE_OK;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -223,6 +223,58 @@ static void test_socp()
     CHECK(CSIPfreeModel(m));
 }
 
+static void test_quadobj()
+{
+    /*
+      min x^2 + y^2
+      s.t. x + y >= 1
+      -> {0.5, 0.5}
+     */
+
+    int linindices[] = {0, 1};
+    double lincoef[] = {1.0, 1.0};
+    int quadi[] = {0, 1};
+    int quadj[] = {0, 1};
+    double quadcoef[] = {1.0, 1.0};
+    double solution[3];
+
+    CSIP_MODEL *m;
+
+    CHECK(CSIPcreateModel(&m));
+    CHECK(CSIPsetParameter(m, "display/verblevel", 2));
+
+    // x
+    CHECK(CSIPaddVar(m, -INFINITY, INFINITY, CSIP_VARTYPE_CONTINUOUS, NULL));
+    // y
+    CHECK(CSIPaddVar(m, -INFINITY, INFINITY, CSIP_VARTYPE_CONTINUOUS, NULL));
+
+    mu_assert_int("Wrong number of vars!", CSIPgetNumVars(m), 2);
+
+    // sparse quadratic objective
+    CHECK(CSIPsetQuadObj(m, 0, NULL, NULL, 2, quadi, quadj, quadcoef));
+
+    // sparse constraint
+    CHECK(CSIPaddLinCons(m, 2, linindices, lincoef, 1.0, INFINITY, NULL));
+
+    mu_assert_int("Wrong number of conss!", CSIPgetNumConss(m), 1);
+
+    CHECK(CSIPsolve(m));
+
+    int solvestatus = CSIPgetStatus(m);
+    mu_assert_int("Wrong status!", solvestatus, CSIP_STATUS_OPTIMAL);
+
+    double objval = CSIPgetObjValue(m);
+    mu_assert_near("Wrong objective value!", objval, 0.5);
+
+    CHECK(CSIPgetVarValues(m, solution));
+
+    // use weaker check, because of nonlinear constraint's abstol
+    mu_assert("Wrong solution!", fabs(solution[0] - 0.5) < 0.01);
+    mu_assert("Wrong solution!", fabs(solution[1] - 0.5) < 0.01);
+
+    CHECK(CSIPfreeModel(m));
+}
+
 struct MyData
 {
     int foo;
@@ -665,6 +717,78 @@ static void test_changeprob()
     CHECK(CSIPfreeModel(m));
 }
 
+static void test_changequadprob()
+{
+    /* Solve two problems in a row:
+      min x^2 + y^2
+      s.t. x + y >= 1
+      -> {0.5, 0.5}
+
+      min x^2 - y
+          x + y == 1
+          -> (-0.5, 1.5)
+     */
+
+    int linindices[] = {0, 1};
+    double lincoef[] = {1.0, 1.0};
+    int quadi[] = {0, 1};
+    int quadj[] = {0, 1};
+    double quadcoef[] = {1.0, 1.0};
+    double solution[3];
+
+    CSIP_MODEL *m;
+
+    CHECK(CSIPcreateModel(&m));
+    CHECK(CSIPsetParameter(m, "display/verblevel", 2));
+
+    // x
+    CHECK(CSIPaddVar(m, -INFINITY, INFINITY, CSIP_VARTYPE_CONTINUOUS, NULL));
+    // y
+    CHECK(CSIPaddVar(m, -INFINITY, INFINITY, CSIP_VARTYPE_CONTINUOUS, NULL));
+
+    mu_assert_int("Wrong number of vars!", CSIPgetNumVars(m), 2);
+
+    // sparse quadratic objective
+    CHECK(CSIPsetQuadObj(m, 0, NULL, NULL, 2, quadi, quadj, quadcoef));
+
+    // sparse constraint
+    CHECK(CSIPaddLinCons(m, 2, linindices, lincoef, 1.0, INFINITY, NULL));
+
+    mu_assert_int("Wrong number of conss!", CSIPgetNumConss(m), 1);
+
+    CHECK(CSIPsolve(m));
+
+    int solvestatus = CSIPgetStatus(m);
+    mu_assert_int("Wrong status!", solvestatus, CSIP_STATUS_OPTIMAL);
+
+    double objval = CSIPgetObjValue(m);
+    mu_assert_near("Wrong objective value!", objval, 0.5);
+
+    CHECK(CSIPgetVarValues(m, solution));
+
+    // use weaker check, because of nonlinear constraint's abstol
+    mu_assert("Wrong solution!", fabs(solution[0] - 0.5) < 0.01);
+    mu_assert("Wrong solution!", fabs(solution[1] - 0.5) < 0.01);
+
+
+    // second problem, modifying the first
+    CHECK(CSIPsetQuadObj(m, 1, &linindices[1], (double[]){-1.0}, 1, quadi, quadj, quadcoef));
+
+    // sparse constraint
+    CHECK(CSIPaddLinCons(m, 2, linindices, lincoef, -INFINITY, 1.0, NULL));
+
+    CHECK(CSIPsolve(m));
+    mu_assert_int("Wrong status!", CSIPgetStatus(m), CSIP_STATUS_OPTIMAL);
+    mu_assert_near("Wrong objective value!", CSIPgetObjValue(m), -1.25);
+
+    CHECK(CSIPgetVarValues(m, solution));
+    // use weaker check, because of nonlinear constraint's abstol
+    mu_assert("Wrong solution!", fabs(solution[0] + 0.5) < 0.01);
+    mu_assert("Wrong solution!", fabs(solution[1] - 1.5) < 0.01);
+
+    CHECK(CSIPfreeModel(m));
+}
+
 static void test_changevartype()
 {
     // solve two problems in a row:
@@ -824,6 +948,7 @@ int main(int argc, char **argv)
     mu_run_test(test_mip2);
     mu_run_test(test_mip3);
     mu_run_test(test_socp);
+    mu_run_test(test_quadobj);
     mu_run_test(test_lazy);
     mu_run_test(test_lazy2);
     mu_run_test(test_lazy_interrupt);
@@ -834,6 +959,7 @@ int main(int argc, char **argv)
     mu_run_test(test_manythings);
     mu_run_test(test_doublelazy);
     mu_run_test(test_changeprob);
+    mu_run_test(test_changequadprob);
     mu_run_test(test_changevartype);
     mu_run_test(test_initialsol);
     mu_run_test(test_heurcb);

--- a/test/test.c
+++ b/test/test.c
@@ -773,7 +773,13 @@ static void test_changequadprob()
 
     // second problem, modifying the first
     CHECK(CSIPsetSenseMaximize(m));
-    CHECK(CSIPsetQuadObj(m, 1, &linindices[1], (double[]){1.0}, 1, quadi, quadj, (double[]){-1.0}));
+    CHECK(CSIPsetQuadObj(m, 1, &linindices[1], (double[])
+    {
+        1.0
+    }, 1, quadi, quadj, (double[])
+    {
+        -1.0
+    }));
 
     // sparse constraint
     CHECK(CSIPaddLinCons(m, 2, linindices, lincoef, -INFINITY, 1.0, NULL));

--- a/test/test.c
+++ b/test/test.c
@@ -724,7 +724,7 @@ static void test_changequadprob()
       s.t. x + y >= 1
       -> {0.5, 0.5}
 
-      min x^2 - y
+      max -x^2 + y
           x + y == 1
           -> (-0.5, 1.5)
      */
@@ -772,14 +772,15 @@ static void test_changequadprob()
 
 
     // second problem, modifying the first
-    CHECK(CSIPsetQuadObj(m, 1, &linindices[1], (double[]){-1.0}, 1, quadi, quadj, quadcoef));
+    CHECK(CSIPsetSenseMaximize(m));
+    CHECK(CSIPsetQuadObj(m, 1, &linindices[1], (double[]){1.0}, 1, quadi, quadj, (double[]){-1.0}));
 
     // sparse constraint
     CHECK(CSIPaddLinCons(m, 2, linindices, lincoef, -INFINITY, 1.0, NULL));
 
     CHECK(CSIPsolve(m));
     mu_assert_int("Wrong status!", CSIPgetStatus(m), CSIP_STATUS_OPTIMAL);
-    mu_assert_near("Wrong objective value!", CSIPgetObjValue(m), -1.25);
+    mu_assert_near("Wrong objective value!", CSIPgetObjValue(m), 1.25);
 
     CHECK(CSIPgetVarValues(m, solution));
     // use weaker check, because of nonlinear constraint's abstol


### PR DESCRIPTION
The idea (or hack) is
1. store objective variable for nonlinear objectives in the model
2. add an auxiliary constraint with the `objvar` to represent the nonlinear objectives.
3. whenever the objective gets change, we 
   * set the objective coefficient of `objvar` to 0 the objective coefficient of `objvar`
   * set bounds of `objvar` to -\infty, \infty (and so the auxiliary constraint is redundant)
   *  release `objvar`
   * create a new `objvar` and a new auxiliary constraint (if the new objective is nonlinear)

There are a couple of test missing: passing from linear objective to quadratic and the other way  around... but what can I say